### PR TITLE
By default rescue exception occuring within a fiber.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ rack-fiber_pool
 A Rack middleware component which runs each request in a Fiber from a pool of Fibers.
 
 Requirements
-==============
+============
 
 * Ruby 1.9
 * EventMachine-based server (e.g. thin or rainbows)
@@ -16,9 +16,20 @@ Add a require and use statement to your Rack app.  See example/app.rb for a simp
 which illustrates proper usage.  In general, you want the FiberPool to be inserted as early as
 possible in the middleware pipeline.
 
+Options
+=======
+
+You may fix the pool size, otherwise it defaults to 100:
+
+    use Rack::FiberPool, :size => 25
+
+All exceptions raised by request handled within a fiber are rescued, by default returning a 500 with no body content. You may customize exceptions rescuing by providing a Proc object conforming to Rack's API:
+
+    rescue_exception = Proc.new { |env, exception| [503, {}, exception.message] }
+    use Rack::FiberPool, :rescue_exception => rescue_exception
 
 Rails
-========
+=====
 
 You can see your app's current pipeline of Rack middleware using:
 
@@ -39,7 +50,7 @@ You can explicitly place the FiberPool like so:
 
     ActionController::Dispatcher.middleware.insert_before ActionController::Session::CookieStore, Rack::FiberPool
 
-    
+
 Thanks to
 ==========
 
@@ -47,6 +58,6 @@ Eric Wong - for adding explicit support for Rack::FiberPool to rainbows.
 
 
 Author
-=========
+======
 
 Mike Perham, [Twitter](http://twitter.com/mperham), [Github](http://github.com/mperham), mperham AT gmail.com.

--- a/test/test_rack-fiber_pool.rb
+++ b/test/test_rack-fiber_pool.rb
@@ -17,7 +17,32 @@ class TestRackFiberPool < MiniTest::Unit::TestCase
     end
     assert_equal [200, {"Content-Type"=>"text/plain"}, ["Hello world!"]], app.result
   end
-  
+
+  def test_exception
+    app = TestBuggyApp.new
+    catch :async do
+      res = Rack::MockRequest.new(Rack::FiberPool.new(app)).get("/")
+    end
+    assert_equal [500, {}, ""], app.result
+  end
+
+  def test_custom_rescue_exception
+    app = TestBuggyApp.new
+    catch :async do
+      rescue_exception = Proc.new { |env, exception| [503, {}, exception.message] }
+      res = Rack::MockRequest.new(Rack::FiberPool.new(app, :rescue_exception => rescue_exception)).get('/')
+    end
+    assert_equal [503, {}, "I'm buggy! Please fix me."], app.result
+  end
+
+  class TestBuggyApp
+    attr_accessor :result
+    def call(env)
+      env['async.callback'] = proc { |result| @result = result }
+      raise Exception.new("I'm buggy! Please fix me.")
+    end
+  end
+
   class TestApp
     attr_accessor :result
     def call(env)


### PR DESCRIPTION
Add rescue_exception option to override the default behavior.

We have played with sinatra-synchrony today and when an exception occurs after the fiber has been resumed at least once, we have no way to catch the exception. In this case the rack stack crash.
