### PR TITLE
Fix response from rescued exceptions conform to rack spec.

### DIFF
--- a/lib/rack/fiber_pool.rb
+++ b/lib/rack/fiber_pool.rb
@@ -11,7 +11,7 @@ module Rack
     def initialize(app, options={})
       @app = app
       @fiber_pool = ::FiberPool.new(options[:size] || SIZE)
-      @rescue_exception = options[:rescue_exception] || Proc.new { |env, e| [500, {}, "#{e.class.name}: #{e.message.to_s}"] }
+      @rescue_exception = options[:rescue_exception] || Proc.new { |env, e| [500, {}, ["#{e.class.name}: #{e.message.to_s}"]] }
       yield @fiber_pool if block_given?
     end
 

--- a/test/test_rack-fiber_pool.rb
+++ b/test/test_rack-fiber_pool.rb
@@ -23,16 +23,16 @@ class TestRackFiberPool < MiniTest::Unit::TestCase
     catch :async do
       res = Rack::MockRequest.new(Rack::FiberPool.new(app)).get("/")
     end
-    assert_equal [500, {}, "Exception: I'm buggy! Please fix me."], app.result
+    assert_equal [500, {}, ["Exception: I'm buggy! Please fix me."]], app.result
   end
 
   def test_custom_rescue_exception
     app = TestBuggyApp.new
     catch :async do
-      rescue_exception = Proc.new { |env, exception| [503, {}, exception.message] }
+      rescue_exception = Proc.new { |env, exception| [503, {}, [exception.message]] }
       res = Rack::MockRequest.new(Rack::FiberPool.new(app, :rescue_exception => rescue_exception)).get('/')
     end
-    assert_equal [503, {}, "I'm buggy! Please fix me."], app.result
+    assert_equal [503, {}, ["I'm buggy! Please fix me."]], app.result
   end
 
   class TestBuggyApp


### PR DESCRIPTION
The body part of the response must respond to each, and yield strings.
see "The Body" in: http://rack.rubyforge.org/doc/files/SPEC.html.
