### PR TITLE
Not compatible with Sinatra's streaming

### DIFF
--- a/lib/rack/fiber_pool.rb
+++ b/lib/rack/fiber_pool.rb
@@ -17,11 +17,12 @@ module Rack
 
     def call(env)
       call_app = lambda do
+        env['async.orig_callback'] = env.delete('async.callback')
         begin
           result = @app.call(env)
-          env['async.callback'].call result
+          env['async.orig_callback'].call result
         rescue ::Exception => e
-          env['async.callback'].call @rescue_exception.call(env, e)
+          env['async.orig_callback'].call @rescue_exception.call(env, e)
         end
       end
 

--- a/test/test_rack-fiber_pool.rb
+++ b/test/test_rack-fiber_pool.rb
@@ -38,7 +38,7 @@ class TestRackFiberPool < MiniTest::Unit::TestCase
   class TestBuggyApp
     attr_accessor :result
     def call(env)
-      env['async.callback'] = proc { |result| @result = result }
+      env['async.orig_callback'] = proc { |result| @result = result }
       raise Exception.new("I'm buggy! Please fix me.")
     end
   end
@@ -46,7 +46,7 @@ class TestRackFiberPool < MiniTest::Unit::TestCase
   class TestApp
     attr_accessor :result
     def call(env)
-      env['async.callback'] = proc { |result| @result = result }
+      env['async.orig_callback'] = proc { |result| @result = result }
       [200, {"Content-Type" => "text/plain"}, ["Hello world!"]]
     end
   end


### PR DESCRIPTION
If you wish to use Sinatra's asynchronous streaming, async.callback should be undefined downstream on the rack.
